### PR TITLE
fix: Delete response

### DIFF
--- a/WAW.API.Tests/Features/Company.feature
+++ b/WAW.API.Tests/Features/Company.feature
@@ -25,7 +25,7 @@ In order to make it available for client applications.
     When a POST request is sent to Companies
       | Name   | Address          | Email           |
       | Oracle | Buenos Aires, AR | oracle@fake.com |
-    Then a CompanyResource response with status 200 is received
+    Then a CompanyResource response with status 201 is received
     And a CompanyResource is included in the body
       | Id | Name   | Address          | Email           |
       | 3  | Oracle | Buenos Aires, AR | oracle@fake.com |
@@ -59,4 +59,4 @@ In order to make it available for client applications.
       | Id | Name        | Address  | Email           |
       | 1  | Google Inc. | Lima, PE | google@fake.com |
     When a DELETE request is sent to Companies with Id 1
-    Then a CompanyResource response with status 200 is received
+    Then a CompanyResource response with status 204 is received

--- a/WAW.API.Tests/Features/Company.feature
+++ b/WAW.API.Tests/Features/Company.feature
@@ -25,7 +25,7 @@ In order to make it available for client applications.
     When a POST request is sent to Companies
       | Name   | Address          | Email           |
       | Oracle | Buenos Aires, AR | oracle@fake.com |
-    Then a CompanyResource response with status 201 is received
+    Then a CompanyResource response with status 200 is received
     And a CompanyResource is included in the body
       | Id | Name   | Address          | Email           |
       | 3  | Oracle | Buenos Aires, AR | oracle@fake.com |

--- a/WAW.API/Auth/Controllers/UsersController.cs
+++ b/WAW.API/Auth/Controllers/UsersController.cs
@@ -62,15 +62,15 @@ public class UsersController : ControllerBase {
   }
 
   [HttpDelete("{id:int}")]
-  [ProducesResponseType(typeof(UserResource), 200)]
+  [ProducesResponseType(typeof(NoContentResult), 204)]
   [ProducesResponseType(typeof(List<string>), 400)]
   [ProducesResponseType(500)]
-  [SwaggerResponse(200, "The user was deleted successfully", typeof(UserResource))]
+  [SwaggerResponse(204, "The user was deleted successfully", typeof(NoContentResult))]
   [SwaggerResponse(400, "The selected user to delete does not exist")]
   public async Task<IActionResult> DeleteAsync(
     [FromRoute] [SwaggerParameter("User identifier", Required = true)] int id
   ) {
-    var result = await service.Delete(id);
-    return result.ToResponse<UserResource>(this, mapper);
+    await service.Delete(id);
+    return NoContent();
   }
 }

--- a/WAW.API/Chat/Controllers/ChatRoomController.cs
+++ b/WAW.API/Chat/Controllers/ChatRoomController.cs
@@ -114,15 +114,15 @@ public class ChatRoomController : ControllerBase {
   }
 
   [HttpDelete("{id:long}")]
-  [ProducesResponseType(typeof(ChatRoomResource), 200)]
+  [ProducesResponseType(typeof(NoContentResult), 204)]
   [ProducesResponseType(typeof(List<string>), 400)]
   [ProducesResponseType(500)]
-  [SwaggerResponse(200, "The chat room was deleted successfully", typeof(ChatRoomResource))]
+  [SwaggerResponse(204, "The chat room was deleted successfully", typeof(NoContentResult))]
   [SwaggerResponse(400, "The selected chat room to delete does not exist")]
   public async Task<IActionResult> DeleteAsync(
     [FromRoute] [SwaggerParameter("ChatRoom identifier", Required = true)] long id
   ) {
-    var result = await chatService.Delete(id);
-    return result.ToResponse<ChatRoomResource>(this, mapper);
+    await chatService.Delete(id);
+    return NoContent();
   }
 }

--- a/WAW.API/Chat/Controllers/MessageController.cs
+++ b/WAW.API/Chat/Controllers/MessageController.cs
@@ -48,15 +48,15 @@ public class MessageController : ControllerBase {
   }
 
   [HttpDelete("{id:long}")]
-  [ProducesResponseType(typeof(MessageResource), 200)]
+  [ProducesResponseType(typeof(NoContentResult), 204)]
   [ProducesResponseType(typeof(List<string>), 400)]
   [ProducesResponseType(500)]
-  [SwaggerResponse(200, "The message was deleted successfully", typeof(MessageResource))]
+  [SwaggerResponse(204, "The message was deleted successfully", typeof(NoContentResult))]
   [SwaggerResponse(400, "The selected message to delete does not exist")]
   public async Task<IActionResult> DeleteAsync(
     [FromRoute] [SwaggerParameter("Message identifier", Required = true)] long id
   ) {
-    var result = await service.Delete(id);
-    return result.ToResponse<MessageResponse>(this, mapper);
+    await service.Delete(id);
+    return NoContent();
   }
 }

--- a/WAW.API/Employers/Controllers/CompaniesController.cs
+++ b/WAW.API/Employers/Controllers/CompaniesController.cs
@@ -66,15 +66,15 @@ public class CompaniesController : ControllerBase {
   }
 
   [HttpDelete("{id:int}")]
-  [ProducesResponseType(typeof(CompanyResource), 200)]
+  [ProducesResponseType(typeof(NoContentResult), 204)]
   [ProducesResponseType(typeof(List<string>), 400)]
   [ProducesResponseType(500)]
-  [SwaggerResponse(200, "The company was deleted successfully", typeof(CompanyResource))]
+  [SwaggerResponse(204, "The company was deleted successfully", typeof(NoContentResult))]
   [SwaggerResponse(400, "The selected company to delete does not exist")]
   public async Task<IActionResult> DeleteAsync(
     [FromRoute] [SwaggerParameter("Company identifier", Required = true)] int id
   ) {
-    var result = await service.Delete(id);
-    return result.ToResponse<CompanyResource>(this, mapper);
+    await service.Delete(id);
+    return NoContent();
   }
 }

--- a/WAW.API/Job/Controllers/OffersController.cs
+++ b/WAW.API/Job/Controllers/OffersController.cs
@@ -62,15 +62,15 @@ public class OffersController : ControllerBase {
   }
 
   [HttpDelete("{id:int}")]
-  [ProducesResponseType(typeof(OfferResource), 200)]
+  [ProducesResponseType(typeof(NoContentResult), 204)]
   [ProducesResponseType(typeof(List<string>), 400)]
   [ProducesResponseType(500)]
-  [SwaggerResponse(200, "The job offer was deleted successfully", typeof(OfferResource))]
+  [SwaggerResponse(204, "The job offer was deleted successfully", typeof(NoContentResult))]
   [SwaggerResponse(400, "The selected job offer to delete does not exist")]
   public async Task<IActionResult> DeleteAsync(
     [FromRoute] [SwaggerParameter("Job offer identifier", Required = true)] int id
   ) {
-    var result = await service.Delete(id);
-    return result.ToResponse<OfferResource>(this, mapper);
+    await service.Delete(id);
+    return NoContent();
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--
Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.
https://guides.github.com/features/mastering-markdown/
-->

### What does it do

Changed the delete response to an No Content with status code 204.

### Why is it needed

When a delete request is sent, is not a good practice to show the resource in the response body. We want to make the client know that the item was deleted successfully and is no longer available.

### Related issue(s)/PR(s)

Fixes #26.